### PR TITLE
Use the amara interface instead of universal subtitles.

### DIFF
--- a/wp_amara_shortcode.php
+++ b/wp_amara_shortcode.php
@@ -36,11 +36,56 @@ if(!class_exists('WP_Amara_Shortcode'))
 		public function __construct() {
 			add_shortcode( 'amara' , array(&$this, 'amara') );
 		} // __construct
-		
+
 		/**
 		 * Main plugin function
 		 */
 		public function amara( $atts ) {
+			// TODO: make a UI for this option
+			if (get_option('wp_amara_use_legacy', true) ) {
+				return $this->unisub($atts);
+			}
+			else {
+				wp_enqueue_script('amara-embed-js');
+				// <div class="amara-embed" data-height="480px" data-width="854px" data-url="http://www.youtube.com/watch?v=5CKwCfLUwj4"></div>
+				// These will be prefixed by 'data-'
+				$data = array(
+					'width' => 640,
+					'height' => 480,
+					// TODO: replace by tutorial video
+					'url' => 'http://www.youtube.com/watch?v=5CKwCfLUwj4',
+				);
+
+				$attributes = array();
+				$attributes['class'] = 'amara-embed';
+				foreach($data as $key => $default) {
+					if (isset($atts[$key])) {
+						$attributes['data-' . $key] = $atts[$key];
+						unset($atts[$key]);
+					}
+					else {
+						$attributes['data-' . $key] = $default;
+					}
+				}
+				$result = '<div ';
+				foreach($attributes as $key => $value) {
+					// TODO escape $value attributes
+					$result.= $key . '="' . $value . '" ';
+				}
+				$result.= '></div>';
+				if (!empty($atts)) {
+					$result .= '<code>' . print_r($atts, true) . '</code>';
+				}
+				return $result;
+			}
+		}
+
+		/**
+		 * @deprecated
+		 *
+		 * Legacy implementation
+		 */
+		public function unisub( $atts) {
 
 			if(isset($atts['content'])) {
 				$content = $this->prepare_content($atts['content']);
@@ -124,4 +169,10 @@ code;
 if(class_exists('WP_Amara_Shortcode')) {
 	// instantiate the plugin class
 	$wp_amara_shortcode = new WP_Amara_Shortcode();
+}
+
+add_action("wp_enqueue_scripts", "WP_Amara_scripts");
+
+function WP_Amara_scripts() {
+	wp_register_script( 'amara-embed-js', 'https://amara.org/embedder-iframe' , '', '', true );
 }


### PR DESCRIPTION
This is a first shot at using the new Amara UI as described at https://github.com/pculture/unisubs/wiki/Embed-Code-Usage-Guide as where the Universal Subtitles is https://github.com/pculture/unisubs/wiki/Legacy-Embed-Code-Usage-Guide

The new Amara is currently disabled as there as some features to test.

### Use Amara

```bash
wp option set wp_amara_use_legacy 0 
```

### Use Universal subtitles

```bash
wp option set wp_amara_use_legacy 1
```

## Open issues

- [ ] Add UI for setting the new Amara On|Off
- [ ] Add UI for default width and height (which makes users to only set the URL
- [ ] Fix the other TODOs
- [x] Are all old providers supported especially *.flv?